### PR TITLE
Remove character limit on textboxes

### DIFF
--- a/src/Program.cpp
+++ b/src/Program.cpp
@@ -25,10 +25,10 @@ Program::Program() : m_window(sf::VideoMode(800,900), "Chatroom", sf::Style::Clo
     m_createRoomButton.SetButtonPosition(sf::Vector2f(600, 700));
     std::function serverFunc = [this] {
         m_username = m_nameBox.GetString();
-        if(!m_username.empty() && !m_portBox.GetString().isEmpty())
+        if(!m_username.empty() && !m_portBox.GetString().empty())
         {
-            m_address = m_addressBox.GetString().toAnsiString();
-            std::string portStr = m_portBox.GetString().toAnsiString();
+            m_address = m_addressBox.GetString();
+            std::string portStr = m_portBox.GetString();
             try
             {
                 m_port = std::stoi(portStr);
@@ -46,10 +46,10 @@ Program::Program() : m_window(sf::VideoMode(800,900), "Chatroom", sf::Style::Clo
     m_joinRoomButton.SetButtonPosition(sf::Vector2f(200, 700));
     std::function clientFunc = [this] {
         m_username = m_nameBox.GetString();
-        if(!m_username.empty() && !m_addressBox.GetString().isEmpty() && !m_portBox.GetString().isEmpty() && !m_networkThread.joinable())
+        if(!m_username.empty() && !m_addressBox.GetString().empty() && !m_portBox.GetString().empty() && !m_networkThread.joinable())
         {
-            m_address = m_addressBox.GetString().toAnsiString();
-            std::string portStr = m_portBox.GetString().toAnsiString();
+            m_address = m_addressBox.GetString();
+            std::string portStr = m_portBox.GetString();
             try
             {
                 m_port = std::stoi(portStr);
@@ -185,7 +185,7 @@ void Program::HandleKeyboardInput(sf::Keyboard::Key key)
             m_window.close();
         break;
         case sf::Keyboard::Enter:
-            if(m_mode == Mode::CHAT && !m_textBox.GetString().isEmpty())
+            if(m_mode == Mode::CHAT && !m_textBox.GetString().empty())
             {
                 if(m_type == NetworkType::SERVER)
                 {

--- a/src/TextContainer.cpp
+++ b/src/TextContainer.cpp
@@ -52,29 +52,37 @@ void TextContainer::PushText(sf::String str)
     text.setCharacterSize(30);
     text.setFillColor(sf::Color::Black);
 
-
-    if(m_texts.empty())
+    do
     {
-        text.setPosition(m_container.getGlobalBounds().left + 10, m_container.getGlobalBounds().top + m_spacing);
-    }else
-    {
-        text.setPosition(m_container.getGlobalBounds().left + 10, m_texts[m_texts.size()-1].getPosition().y + m_textHeight);
-        //If the texts size is greater than the capacity of the container (14), then we scroll once and add to the scroll index
-        if(m_texts.size() >= 14)
+        int i;
+        for(i = text.getString().getSize(); text.getGlobalBounds().width + 15 > m_container.getGlobalBounds().width; i--)
         {
-            text.move(0, -m_textHeight);
-            m_scrollIndex++;
-            Scroll(-1);
+            text.setString(text.getString().substring(0, i));
         }
-    }
-    m_texts.emplace_back(text);
-    if(m_scrollIndex < static_cast<int>(m_texts.size())-14)
-    {
-        Scroll(m_scrollIndex - (static_cast<int>(m_texts.size())-14));
-        m_scrollIndex = static_cast<int>(m_texts.size())-14;
-    }
-    m_spacing += m_textHeight;
-
+        str = str.substring(i);
+        if(m_texts.empty())
+        {
+            text.setPosition(m_container.getGlobalBounds().left + 10, m_container.getGlobalBounds().top + m_spacing);
+        }else
+        {
+            text.setPosition(m_container.getGlobalBounds().left + 10, m_texts[m_texts.size()-1].getPosition().y + m_textHeight);
+            //If the texts size is greater than the capacity of the container (14), then we scroll once and add to the scroll index
+            if(m_texts.size() >= 14)
+            {
+                text.move(0, -m_textHeight);
+                m_scrollIndex++;
+                Scroll(-1);
+            }
+        }
+        m_texts.emplace_back(text);
+        if(m_scrollIndex < static_cast<int>(m_texts.size())-14)
+        {
+            Scroll(m_scrollIndex - (static_cast<int>(m_texts.size())-14));
+            m_scrollIndex = static_cast<int>(m_texts.size())-14;
+        }
+        m_spacing += m_textHeight;
+        text.setString(str);
+    }while(!str.isEmpty());
 }
 
 void TextContainer::draw(sf::RenderTarget &target, sf::RenderStates states) const

--- a/src/Textbox.cpp
+++ b/src/Textbox.cpp
@@ -82,8 +82,13 @@ void Textbox::ProcessText(sf::Uint32 unicode)
         {
             ScrollText(1);
             m_textRenderOffset--;
+
         }
         m_text.setString(m_textBoxText.substr(m_textRenderOffset));
+        if(m_text.getGlobalBounds().width + 50 >= m_textBoxSpriteBounds.width)
+        {
+            m_textRenderOffset++;
+        }
     }
     //Push char
     else if(unicode != '\r')

--- a/src/Textbox.cpp
+++ b/src/Textbox.cpp
@@ -8,7 +8,7 @@
 
 #include "ResourceLoader.h"
 
-Textbox::Textbox(const sf::Vector2f& size, const sf::Vector2f& position) : m_bActive(false), m_blinkCounter(0)
+Textbox::Textbox(const sf::Vector2f& size, const sf::Vector2f& position) : m_bActive(false), m_blinkCounter(0), m_textRenderOffset(0)
 {
     m_textBoxTexture.loadFromFile("../assets/rectBox.png");
     m_textBoxSprite.setTexture(m_textBoxTexture);
@@ -16,19 +16,32 @@ Textbox::Textbox(const sf::Vector2f& size, const sf::Vector2f& position) : m_bAc
     m_textBoxSprite.setScale((size.x/400)*0.05,0.05);
     m_textBoxSprite.setPosition(position);
 
+
+    //PNG is 8192x2774, sprite frame is 7100x1570
+    //These values compute the value of the actual frame
+    m_textBoxSpriteBounds = m_textBoxSprite.getGlobalBounds();
+    m_textBoxSpriteBounds.left += m_textBoxSpriteBounds.width/16;
+    m_textBoxSpriteBounds.width *= 7.0f/8.0f;
+    m_textBoxSpriteBounds.top += m_textBoxSpriteBounds.height * 28.f/99.f;
+    m_textBoxSpriteBounds.height *= 56.f/99.f;
+
+
+
     m_cursor.setFont(Resources::CursorFont);
 
     m_cursor.setString("l");
     m_cursor.setCharacterSize(50);
     m_cursor.setFillColor(sf::Color::Black);
-    m_cursor.setOrigin(m_cursor.getLocalBounds().width/2, m_cursor.getLocalBounds().height/2);
-    m_cursor.setPosition(m_textBoxSprite.getGlobalBounds().left + size.x/8, m_textBoxSprite.getGlobalBounds().top + m_textBoxSprite.getGlobalBounds().height/2-15);
+    m_cursor.setOrigin(m_cursor.getGlobalBounds().width/2, m_cursor.getGlobalBounds().height/2);
+    m_cursor.setPosition(m_textBoxSpriteBounds.left + 25, m_textBoxSpriteBounds.top+15);
 
     m_text.setFont(Resources::CursorFont);
     m_text.setString("");
     m_text.setCharacterSize(40);
     m_text.setFillColor(sf::Color::Black);
-    m_text.setPosition(m_textBoxSprite.getGlobalBounds().left + size.x/8, m_textBoxSprite.getGlobalBounds().top + m_textBoxSprite.getGlobalBounds().height/2-25);
+    m_text.setPosition(m_textBoxSpriteBounds.left + 25, m_textBoxSpriteBounds.top+3);
+
+
 
 }
 
@@ -60,16 +73,37 @@ void Textbox::ManageTextBox(sf::RenderWindow* window, sf::Event event)
 
 void Textbox::ProcessText(sf::Uint32 unicode)
 {
-
+    //Backspace
     if(unicode == 8)
     {
-        m_text.setString(m_text.getString().substring(0, m_text.getString().getSize()-1));
-    }else if(m_text.getLocalBounds().width + 50 <= m_textBoxSprite.getGlobalBounds().width - 140 && unicode != '\r')
-    {
-        m_text.setString(m_text.getString() + unicode);
+        if(m_textBoxText.empty())return;
+        m_textBoxText.pop_back();
+        if(m_textRenderOffset > 0)
+        {
+            ScrollText(1);
+            m_textRenderOffset--;
+        }
+        m_text.setString(m_textBoxText.substr(m_textRenderOffset));
     }
+    //Push char
+    else if(unicode != '\r')
+    {
+        m_textBoxText += unicode;
+        m_text.setString(m_textBoxText.substr(m_textRenderOffset));
+        while(m_text.getGlobalBounds().width + 50 >= m_textBoxSpriteBounds.width)
+        {
+            ScrollText(-1);
+            m_textRenderOffset++;
+            m_text.setString(m_textBoxText.substr(m_textRenderOffset));
+        }
+    }
+    //Move cursor
     m_cursor.setPosition(m_text.getGlobalBounds().left + m_text.getGlobalBounds().width, m_cursor.getPosition().y);
 
+}
+
+void Textbox::ScrollText(int right)
+{
 }
 
 void Textbox::ManageCursorBlink(float dt)
@@ -93,11 +127,13 @@ void Textbox::SetActive(bool bIsActive)
 void Textbox::ClearString()
 {
     m_text.setString("");
+    m_textBoxText.clear();
+    m_textRenderOffset = 0;
 }
 
-const sf::String & Textbox::GetString()
+const std::string& Textbox::GetString()
 {
-    return m_text.getString();
+    return m_textBoxText;
 }
 
 void Textbox::draw(sf::RenderTarget &target, sf::RenderStates states) const

--- a/src/Textbox.h
+++ b/src/Textbox.h
@@ -13,11 +13,13 @@ class Textbox : public sf::Drawable{
 
     sf::Texture m_textBoxTexture;
     sf::Sprite m_textBoxSprite;
+    sf::FloatRect m_textBoxSpriteBounds;
     sf::Text m_cursor;
     float m_blinkCounter;
 
     sf::Text m_text;
-
+    std::string m_textBoxText;
+    int m_textRenderOffset;
 
 
     float m_cursorBlinkRate = 1.0f;
@@ -26,10 +28,11 @@ public:
     Textbox(const sf::Vector2f& size, const sf::Vector2f& position);
     void ManageTextBox(sf::RenderWindow* window, sf::Event event);
     void ProcessText(sf::Uint32 unicode);
+    void ScrollText(int right);
     void ManageCursorBlink(float dt);
     void SetActive(bool bIsActive);
     void ClearString();
-    const sf::String& GetString();
+    const std::string& GetString();
     void draw(sf::RenderTarget &target, sf::RenderStates states) const override;
 };
 


### PR DESCRIPTION
Textboxes now scroll text when additional characters are added to prevent overflow. Text containers also wrap text that would normally overflow.